### PR TITLE
Updated for APEX 18.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,47 +2,47 @@
 
 This document will keep an up to date version of my personal Oracle dockerized development environment. The main goal is to have one Oracle database with multiple versions of APEX installed. 
 
-This is achieved using Oracle 12c containers (not to be confused with Docker containers). If you're not too familiar with Oracle 12c containers I highly recommend reading [this](http://www.oracle.com/technetwork/articles/database/multitenant-part1-pdbs-2193987.html) article which covers Container Databases (CDB) and Pluggable Databases (PDB).
+This is achieved using Oracle 12c containers (not to be confused with Docker containers). If you're not too familiar with Oracle 12c containers I highly recommend reading [this][1] article which covers Container Databases (CDB) and Pluggable Databases (PDB).
 
 <!-- TOC depthFrom:2 -->
 
-- [Known Issues and Future Improvements](#known-issues-and-future-improvements)
-- [References](#references)
-- [Background](#background)
-  - [Port Mapping](#port-mapping)
-  - [Passwords](#passwords)
-  - [Download Files](#download-files)
-  - [Laptop Folder Structure](#laptop-folder-structure)
-  - [Oracle Container Registry Setup](#oracle-container-registry-setup)
-- [Setup](#setup)
-  - [Directory structure](#directory-structure)
-  - [Docker Network](#docker-network)
-  - [Docker Images](#docker-images)
-    - [Get Oracle Image](#get-oracle-image)
-    - [ORDS](#ords)
-    - [Docker Image Confirmation](#docker-image-confirmation)
-- [Docker Containers](#docker-containers)
-  - [Oracle Container](#oracle-container)
-  - [Oracle CDB and PDB Setup](#oracle-cdb-and-pdb-setup)
-    - [CDB Setup](#cdb-setup)
-    - [PDB Setup](#pdb-setup)
-      - [Create PDBs](#create-pdbs)
-      - [APEX 5.0.4 Install](#apex-504-install)
-      - [APEX 5.1.3 Install](#apex-513-install)
-  - [ORDS Containers](#ords-containers)
-    - [ORDS 5.0.4](#ords-504)
-    - [ORDS 5.1.3](#ords-513)
-    - [ORDS Container Wrappup](#ords-container-wrappup)
-- [Useful Commands](#useful-commands)
-  - [Quick Start](#quick-start)
-  - [Docker](#docker)
-  - [Oracle](#oracle)
-    - [Connection Strings](#connection-strings)
-    - [DBA](#dba)
-    - [Sample Data](#sample-data)
-- [Common Problems](#common-problems)
-  - [Oracle Docker Container](#oracle-docker-container)
-    - [Issues writing to `/ORCL` folder](#issues-writing-to-orcl-folder)
+- [Known Issues and Future Improvements][2]
+- [References][3]
+- [Background][4]
+  - [Port Mapping][5]
+  - [Passwords][6]
+  - [Download Files][7]
+  - [Laptop Folder Structure][8]
+  - [Oracle Container Registry Setup][9]
+- [Setup][10]
+  - [Directory structure][11]
+  - [Docker Network][12]
+  - [Docker Images][13]
+	- [Get Oracle Image][14]
+	- [ORDS][15]
+	- [Docker Image Confirmation][16]
+- [Docker Containers][17]
+  - [Oracle Container][18]
+  - [Oracle CDB and PDB Setup][19]
+	- [CDB Setup][20]
+	- [PDB Setup][21]
+	  - [Create PDBs][22]
+	  - [APEX 5.0.4 Install][23]
+	  - [APEX 5.1.3 Install][24]
+  - [ORDS Containers][25]
+	- [ORDS 5.0.4][26]
+	- [ORDS 5.1.3][27]
+	- [ORDS Container Wrappup][28]
+- [Useful Commands][29]
+  - [Quick Start][30]
+  - [Docker][31]
+  - [Oracle][32]
+	- [Connection Strings][33]
+	- [DBA][34]
+	- [Sample Data][35]
+- [Common Problems][36]
+  - [Oracle Docker Container][37]
+	- [Issues writing to `/ORCL` folder][38]
 
 <!-- /TOC -->
 
@@ -56,25 +56,26 @@ This is achieved using Oracle 12c containers (not to be confused with Docker con
 
  The following articles and all my scripts are a result of a combination of the code found in the links.
  
-- [APEX and ORDS up and running in....2 steps!](http://joelkallman.blogspot.ca/2017/05/apex-and-ords-up-and-running-in2-steps.html) by [Joel Kallman](https://twitter.com/joelkallman)
-- [Dockerize your APEX development environment](http://roelhartman.blogspot.ca/2017/10/dockerize-your-apex-development.html) by [Roel Hartman](https://twitter.com/RoelH)
-- [Oracle Database 12c now available on Docker](https://sqlmaria.com/2017/04/27/oracle-database-12c-now-available-on-docker/) by [Maria Colgan](https://twitter.com/sqlmaria)
+- [APEX and ORDS up and running in....2 steps!][39] by [Joel Kallman][40]
+- [Dockerize your APEX development environment][41] by [Roel Hartman][42]
+- [Oracle Database 12c now available on Docker][43] by [Maria Colgan][44]
 
 ## Background
 
 - All my scripts are Linux / MacOS focused. If you use a Windows machine you'll need to translate
 - I specifically made reference to "your laptop" to emphasize what was run "on your machine" vs "in a docker container"
-- I use [SQLcl](http://www.oracle.com/technetwork/developer-tools/sqlcl/overview/index.html) instead of SQLplus on my laptop. I've also renamed the default command `sql` to `sqlcl`. You can use `sqlplus` or follow my [sqlcl install instructions](http://www.talkapex.com/2015/04/installing-sqlcl/).
+- I use [SQLcl][45] instead of SQLplus on my laptop. I've also renamed the default command `sql` to `sqlcl`. You can use `sqlplus` or follow my [sqlcl install instructions][46].
 
 ### Port Mapping
 
-The following port mapping will be used. To help remember the DB version, the database port ends in its version number `122` for `12.2`. Likewise, the ORDS ports end in the APEX version they link to ex: `513` for `5.1.3`.
+The following port mapping will be used. To help remember the DB version, the database port ends in its version number `122` for `12.2`. Likewise, the ORDS ports end in the APEX version they link to ex: `513` for `5.1.3`, `1810` for `18.1.0`.
 
 Container | Container Port | Laptop Port | Description
 --- | --- | --- | ---
 `oracle` | `1521` | `32122` | TNS listener for Oracle 12.2
 `ords-504` | `8080` | `32504` | ORDS for APEX 5.0.4
 `ords-513` | `8080` | `32513` | ORDS for APEX 5.1.3
+`ords-1810` | `8080` | `31810` | ORDS for APEX 18.1.0
 
 ### Passwords
 
@@ -91,9 +92,10 @@ Due to licensing restrictions I can't host/provide these files in Github or else
 
 Application | Description
 --- | ---
-[APEX 5.1.3](http://www.oracle.com/technetwork/developer-tools/apex/downloads/index.html) | At the time of writing 5.1.3 was the most recent version.
-[APEX 5.0.4](http://www.oracle.com/technetwork/developer-tools/apex/downloads/all-archives-099381.html) | This is the APEX archive page. Click on the [5.0 Archive](http://www.oracle.com/technetwork/developer-tools/apex/downloads/apex-5-archive-2606313.html) link.
-[ORDS 17.4.1](http://www.oracle.com/technetwork/developer-tools/rest-data-services/downloads) | At the time of writing ORDS 17.4.1 was the most recent version.
+[APEX 18.1][47] | At the time of writing, 18.1 is the most recent version.
+[APEX 5.1.3][48] | Find it in the APEX archive page.
+[APEX 5.0.4][49] | Find it in the APEX archive page.
+[ORDS 17.4.1][50] | At the time of writing ORDS 17.4.1 was the most recent version.
 
 
 ### Laptop Folder Structure
@@ -104,6 +106,7 @@ Path | Description
 --- | ---
 `~/docker` | root
 `~/docker/apex` | APEX installation files and images for each version. 2 versions of APEX are included in this example but more can easily be added
+`~/docker/apex/18.1.0` | APEX 18.1.0 installation files 
 `~/docker/apex/5.1.3` | APEX 5.1.3 installation files  
 `~/docker/apex/5.0.4` | APEX 5.1.3 installation files  
 `~/docker/oracle`  |  Oracle 12.2 data files
@@ -112,7 +115,7 @@ Path | Description
 
 ### Oracle Container Registry Setup
 
-To work with Oracle's licensing for docker (and to avoid manually building images yourself) you'll need to login to the [container-registry.oracle.com](https://container-registry.oracle.com) and use your Oracle Technology Network (OTN) login and register.
+To work with Oracle's licensing for docker (and to avoid manually building images yourself) you'll need to login to the [container-registry.oracle.com][51] and use your Oracle Technology Network (OTN) login and register.
 
 One logged in go to `Database > Enterprise` and read the license agreement. If you agree to the Terms and Conditions click the Accept button.
 
@@ -141,11 +144,14 @@ cd ~/docker/apex
 cp ~/Downloads/apex*.zip .
 
 # Unzip
-unzip apex_5.0.4.zip
-mv apex 5.0.4
+unzip apex_18.1_en.zip
+mv apex 18.1.0
 
 unzip apex_5.1.3.zip
 mv apex 5.1.3
+
+unzip apex_5.0.4.zip
+mv apex 5.0.4
 
 # ORDS will be dealt in the ORDS image section
 ```
@@ -166,7 +172,7 @@ docker network inspect oracle_network
 
 ### Docker Images
 
-Two images are required to get the setup working. One for Oracle and one for ORDS.
+Two images are required to get the setup working: Oracle and ORDS.
 
 #### Get Oracle Image
 
@@ -189,9 +195,9 @@ docker pull container-registry.oracle.com/database/enterprise:12.2.0.1
 
 #### ORDS
 
-*Oracle has scripts available to build an ORDS image. At the time of writing (11-Nov-2017) there's an issue with the script ([Issue #646](https://github.com/oracle/docker-images/issues/646)) that prevents me from using it. I suspect that Oracle will include a pre-built image on their container registry in the future so I'll update the section with their image when/if it becomes available. In the mean time the image will be built using another script.*
+*Oracle has scripts available to build an ORDS image. At the time of writing (11-Nov-2017) there's an issue with the script ([Issue #646][52]) that prevents me from using it. I suspect that Oracle will include a pre-built image on their container registry in the future so I'll update the section with their image when/if it becomes available. In the mean time the image will be built using another script.*
 
-**Important:** I've created a separate [ORDS Docker Image](https://github.com/martindsouza/docker-ords) repo. Since it's being actively updated and to avoid duplication of documentation please refer to the repo to build your ORDS Docker image. **Go through it now to create your ORDS Docker image**.
+**Important:** I've created a separate [ORDS Docker Image][53] repo. Since it's being actively updated and to avoid duplication of documentation please refer to the repo to build your ORDS Docker image. **Go through it now to create your ORDS Docker image**.
 
 #### Docker Image Confirmation
 
@@ -213,7 +219,7 @@ Now that the setup is complete we can create all the Docker containers
 
 ### Oracle Container
 
-Adding the `-e TZ` option will set the appropriate timezine for the OS and the database. A full list of timezones can be found [here](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). If excluded it will default to UTC.
+Adding the `-e TZ` option will set the appropriate timezone for the OS and the database. A full list of timezones can be found [here][54]. If excluded it will default to UTC.
 
 ```bash
 docker run -d -it \
@@ -244,7 +250,7 @@ You can follow the install by running `docker logs oracle`
 
 #### CDB Setup
 
-Starting in Oracle 12.2 the database should not come pre-installed with APEX. [Joel Kallman](https://twitter.com/joelkallman) wrote an [article](http://joelkallman.blogspot.ca/2016/03/an-important-change-coming-for-oracle.html) about why this. For some reason the container from Oracle comes with APEX installed in the CDB. It must first be removed.
+Starting in Oracle 12.2 the database should not come pre-installed with APEX. [Joel Kallman][55] wrote an [article][56] about why this. For some reason the container from Oracle comes with APEX 5.1.3 installed in the CDB. It must first be removed.
 
 ```bash
 # On your laptop:
@@ -274,6 +280,10 @@ Note I've included the APEX installs in these sections since they're required fo
 On your laptop connect to the database: `sqlcl sys/Oradoc_db1@localhost:32122:orclcdb as sysdba`
 
 ```sql
+-- Create 18.1.0 PDB
+create pluggable database orclpdb1810 admin user pdb_adm identified by Oradoc_db1
+  file_name_convert=('/u02/app/oracle/oradata/ORCL/pdbseed/','/u02/app/oracle/oradata/ORCL/ORCLPDB1810/');
+
 -- Create 5.1.3 PDB
 create pluggable database orclpdb513 admin user pdb_adm identified by Oradoc_db1
   file_name_convert=('/u02/app/oracle/oradata/ORCL/pdbseed/','/u02/app/oracle/oradata/ORCL/ORCLPDB513/');
@@ -284,18 +294,19 @@ create pluggable database orclpdb504 admin user pdb_adm identified by Oradoc_db1
 
 -- Running the following query will show the newly created PDBs but they are not open for Read Write:
 select vp.name, vp.open_mode
-from v$pdbs vp
-;
+from v$pdbs vp;
 
 NAME        OPEN_MODE
 PDB$SEED    READ WRITE
 ORCLPDB1    READ WRITE
 ORCLPDB513  MOUNTED
 ORCLPDB504  MOUNTED
+ORCLPDB1810 MOUNTED
 
 -- Open the PDB
+alter pluggable database orclpdb1810 open read write;
 alter pluggable database orclpdb513 open read write; 
-alter pluggable database orclpdb504 open read write; 
+alter pluggable database orclpdb504 open read write;
 
 -- If nothing is changed the PDBs won't be loaded on boot.
 -- They're a few ways to do this
@@ -306,6 +317,128 @@ alter pluggable database orclpdb504 open read write;
 alter pluggable database all save state;
 
 -- Exit sqlcl
+exit
+```
+
+##### APEX 18.1.0 Install
+
+```bash
+# On your laptop
+docker exec -it oracle bash -c "source /home/oracle/.bashrc; bash"
+
+# You should now be in the Oracle Docker container
+cd /tmp/apex/18.1.0
+sqlplus sys/Oradoc_db1@localhost/orclpdb1810.localdomain as sysdba
+```
+
+```sql
+@apexins.sql SYSAUX SYSAUX TEMP /i/
+
+-- APEX REST configuration
+@apex_rest_config_core.sql oracle oracle
+
+-- Required for ORDS install
+alter user apex_public_user identified by oracle account unlock;
+
+-- From Joels blog: http://joelkallman.blogspot.ca/2017/05/apex-and-ords-up-and-running-in2-steps.html
+declare
+    l_acl_path varchar2(4000);
+    l_apex_schema varchar2(100);
+begin
+    for c1 in (select schema
+                 from sys.dba_registry
+                where comp_id = 'APEX') loop
+        l_apex_schema := c1.schema;
+    end loop;
+    sys.dbms_network_acl_admin.append_host_ace(
+        host => '*',
+        ace => xs$ace_type(privilege_list => xs$name_list('connect'),
+        principal_name => l_apex_schema,
+        principal_type => xs_acl.ptype_db));
+    commit;
+end;
+/
+
+-- Setup APEX Admin password
+begin
+    apex_util.set_security_group_id( 10 );
+    apex_util.create_user(
+        p_user_name => 'ADMIN',
+        p_email_address => 'martin@talkapex.com',
+        p_web_password => 'Oradoc_db1',
+        p_developer_privs => 'ADMIN',
+        p_change_password_on_first_use => 'N');
+    apex_util.set_security_group_id( null );
+    commit;
+end;
+/
+-- Exit SQL
+exit
+```
+
+```bash
+# You can now exit bash on the container
+exit
+```
+
+##### APEX 5.1.3 Install
+
+```bash
+# On your laptop
+docker exec -it oracle bash -c "source /home/oracle/.bashrc; bash"
+
+# You should now be in the Oracle Docker container
+cd /tmp/apex/5.1.3
+sqlplus sys/Oradoc_db1@localhost/orclpdb513.localdomain as sysdba
+```
+
+```sql
+@apexins.sql SYSAUX SYSAUX TEMP /i/
+
+-- APEX REST configuration
+@apex_rest_config_core.sql oracle oracle
+
+-- Required for ORDS install
+alter user apex_public_user identified by oracle account unlock;
+
+-- From Joels blog: http://joelkallman.blogspot.ca/2017/05/apex-and-ords-up-and-running-in2-steps.html
+declare
+    l_acl_path varchar2(4000);
+    l_apex_schema varchar2(100);
+begin
+    for c1 in (select schema
+                 from sys.dba_registry
+                where comp_id = 'APEX') loop
+        l_apex_schema := c1.schema;
+    end loop;
+    sys.dbms_network_acl_admin.append_host_ace(
+        host => '*',
+        ace => xs$ace_type(privilege_list => xs$name_list('connect'),
+        principal_name => l_apex_schema,
+        principal_type => xs_acl.ptype_db));
+    commit;
+end;
+/
+
+-- Setup APEX Admin password
+begin
+    apex_util.set_security_group_id( 10 );
+    apex_util.create_user(
+        p_user_name => 'ADMIN',
+        p_email_address => 'martin@talkapex.com',
+        p_web_password => 'Oradoc_db1',
+        p_developer_privs => 'ADMIN',
+        p_change_password_on_first_use => 'N');
+    apex_util.set_security_group_id( null );
+    commit;
+end;
+/
+-- Exit SQL
+exit
+```
+
+```bash
+# You can now exit bash on the container
 exit
 ```
 
@@ -373,74 +506,52 @@ exit
 exit
 ```
 
-##### APEX 5.1.3 Install
-
-
-```bash
-# On your laptop
-docker exec -it oracle bash -c "source /home/oracle/.bashrc; bash"
-
-# You should now be in the Oracle Docker container
-cd /tmp/apex/5.1.3
-sqlplus sys/Oradoc_db1@localhost/orclpdb513.localdomain as sysdba
-```
-
-```sql
-@apexins.sql SYSAUX SYSAUX TEMP /i/
-
--- APEX REST configuration
-@apex_rest_config_core.sql oracle oracle
-
--- Required for ORDS install
-alter user apex_public_user identified by oracle account unlock;
-
--- From Joels blog: http://joelkallman.blogspot.ca/2017/05/apex-and-ords-up-and-running-in2-steps.html
-declare
-    l_acl_path varchar2(4000);
-    l_apex_schema varchar2(100);
-begin
-    for c1 in (select schema
-                 from sys.dba_registry
-                where comp_id = 'APEX') loop
-        l_apex_schema := c1.schema;
-    end loop;
-    sys.dbms_network_acl_admin.append_host_ace(
-        host => '*',
-        ace => xs$ace_type(privilege_list => xs$name_list('connect'),
-        principal_name => l_apex_schema,
-        principal_type => xs_acl.ptype_db));
-    commit;
-end;
-/
-
--- Setup APEX Admin password
-begin
-    apex_util.set_security_group_id( 10 );
-    apex_util.create_user(
-        p_user_name => 'ADMIN',
-        p_email_address => 'martin@talkapex.com',
-        p_web_password => 'Oradoc_db1',
-        p_developer_privs => 'ADMIN',
-        p_change_password_on_first_use => 'N');
-    apex_util.set_security_group_id( null );
-    commit;
-end;
-/
--- Exit SQL
-exit
-```
-
-```bash
-# You can now exit bash on the container
-exit
-```
-
 ### ORDS Containers
 
 Each APEX PDB should have an associated ORDS container. A few notes about each ORDS container:
 
 - Instead of naming the ORDS containers with their version number, they'll be named to reference the corresponding APEX version. You may want to alter your naming scheme if you plan to test with multiple versions of ORDS.
-- **Important:** Refer to [Docker ORDS](https://github.com/martindsouza/docker-ords) documentation on how to run each ORDS setup. Only modifications will be mentioned in each section below.
+- **Important:** Refer to [Docker ORDS][57] documentation on how to run each ORDS setup. Only modifications will be mentioned in each section below.
+
+#### ORDS 18.1.0
+
+```bash
+docker run ...
+  --name ords-1810 \
+  --network=oracle_network \
+  -e TZ=America/Edmonton \
+  -e DB_HOSTNAME=oracle \
+  -e DB_PORT=1521 \
+  -e DB_SERVICENAME=orclpdb1810.localdomain \
+  -e APEX_PUBLIC_USER_PASS=oracle \
+  -e APEX_LISTENER_PASS=oracle \
+  -e APEX_REST_PASS=oracle \
+  -e ORDS_PASS=oracle \
+  -e SYS_PASS=Oradoc_db1 \
+  ...
+```
+
+You should now be able to go to APEX via [http://localhost:31810/ords][58]
+
+#### ORDS 5.1.3
+
+```bash
+docker run ...
+  --name ords-513 \
+  --network=oracle_network \
+  -e TZ=America/Edmonton \
+  -e DB_HOSTNAME=oracle \
+  -e DB_PORT=1521 \
+  -e DB_SERVICENAME=orclpdb513.localdomain \
+  -e APEX_PUBLIC_USER_PASS=oracle \
+  -e APEX_LISTENER_PASS=oracle \
+  -e APEX_REST_PASS=oracle \
+  -e ORDS_PASS=oracle \
+  -e SYS_PASS=Oradoc_db1 \
+  ...
+```
+
+You should now be able to go to APEX via http://localhost:32513/ords
 
 #### ORDS 5.0.4
 
@@ -464,31 +575,11 @@ docker run ...
 You should now be able to go to APEX via http://localhost:32504/ords
 
 
-#### ORDS 5.1.3
-
-```bash
-docker run ...
-  --name ords-513 \
-  --network=oracle_network \
-  -e TZ=America/Edmonton \
-  -e DB_HOSTNAME=oracle \
-  -e DB_PORT=1521 \
-  -e DB_SERVICENAME=orclpdb513.localdomain \
-  -e APEX_PUBLIC_USER_PASS=oracle \
-  -e APEX_LISTENER_PASS=oracle \
-  -e APEX_REST_PASS=oracle \
-  -e ORDS_PASS=oracle \
-  -e SYS_PASS=Oradoc_db1 \
-  ...
-```
-
-You should now be able to go to APEX via http://localhost:32513/ords
-
 #### ORDS Container Wrappup
 
-When running ORDS containers for the first time they'll run in the foreground as the `-d` (`detached`) option was not provided (see [Docker documentation](https://docs.docker.com/engine/reference/run/#detached--d) for more info on this option). It's good to have it run in the foreground as it's easy to spot any issues with ORDS connecting to the database.
+When running ORDS containers for the first time they'll run in the foreground as the `-d` (`detached`) option was not provided (see [Docker documentation][59] for more info on this option). It's good to have it run in the foreground as it's easy to spot any issues with ORDS connecting to the database.
 
-To stop stop the container hit `ctrl+c`. To restart the ORDS container run `docker start ords-513`.
+To stop stop the container hit `ctrl+c`. To restart the ORDS container run `docker start ords-1810`.
 
 ## Useful Commands
 
@@ -503,11 +594,13 @@ To quickly start and stop the docker containers:
 docker start oracle
 docker start ords-504
 docker start ords-513
+docker start ords-1810
 
 # Stop
 docker stop -t 200 oracle
 docker stop -t 200 ords-504
 docker stop -t 200 ords-513
+docker stop -t 200 ords-1810
 
 ```
 
@@ -539,8 +632,6 @@ docker network inspect oracle_network
 ```
 
 
-
-
 ### Oracle
 
 #### Connection Strings
@@ -550,6 +641,7 @@ sqlcl sys/Oradoc_db1@localhost:32122:orclcdb as sysdba
 sqlcl sys/Oradoc_db1@localhost:32122/orclpdb1.localdomain as sysdba
 sqlcl sys/Oradoc_db1@localhost:32122/orclpdb504.localdomain as sysdba
 sqlcl sys/Oradoc_db1@localhost:32122/orclpdb513.localdomain as sysdba
+sqlcl sys/Oradoc_db1@localhost:32122/orclpdb1810.localdomain as sysdba
 ```
 
 #### DBA
@@ -557,12 +649,13 @@ sqlcl sys/Oradoc_db1@localhost:32122/orclpdb513.localdomain as sysdba
 ```sql
 
 # Drop PDB
+drop pluggable database orclpdb1810 including datafiles;
 drop pluggable database orclpdb513 including datafiles;
 drop pluggable database orclpdb504 including datafiles;
 
 # Create tablespace (as PDB DBA)
 create tablespace users
-  datafile 'users-514.dat' 
+  datafile 'users-1810.dat' 
     size 100m
     autoextend on
     next 20m
@@ -602,7 +695,7 @@ mkdir: cannot create directory '/ORCL/u01': Permission denied
 
 It could be due to SE Linux. The following worked for me to get around this:
 
-- [Disable SE Linux](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/security-enhanced_linux/sect-security-enhanced_linux-enabling_and_disabling_selinux-disabling_selinux)
+- [Disable SE Linux][60]
   - Set `SELINUX=disabled` in `/etc/selinux/config`
   - Reboot host OS (i.e. laptop)
   - Running `getenforce` should return `Disabled` or `Permissive`
@@ -616,3 +709,64 @@ chmod 777 ~/docker/apex
 chcon -Rt svirt_sandbox_file_t ~/docker/oracle
 chcon -Rt svirt_sandbox_file_t ~/docker/apex
 ```
+
+[1]:	http://www.oracle.com/technetwork/articles/database/multitenant-part1-pdbs-2193987.html
+[2]:	#known-issues-and-future-improvements
+[3]:	#references
+[4]:	#background
+[5]:	#port-mapping
+[6]:	#passwords
+[7]:	#download-files
+[8]:	#laptop-folder-structure
+[9]:	#oracle-container-registry-setup
+[10]:	#setup
+[11]:	#directory-structure
+[12]:	#docker-network
+[13]:	#docker-images
+[14]:	#get-oracle-image
+[15]:	#ords
+[16]:	#docker-image-confirmation
+[17]:	#docker-containers
+[18]:	#oracle-container
+[19]:	#oracle-cdb-and-pdb-setup
+[20]:	#cdb-setup
+[21]:	#pdb-setup
+[22]:	#create-pdbs
+[23]:	#apex-504-install
+[24]:	#apex-513-install
+[25]:	#ords-containers
+[26]:	#ords-504
+[27]:	#ords-513
+[28]:	#ords-container-wrappup
+[29]:	#useful-commands
+[30]:	#quick-start
+[31]:	#docker
+[32]:	#oracle
+[33]:	#connection-strings
+[34]:	#dba
+[35]:	#sample-data
+[36]:	#common-problems
+[37]:	#oracle-docker-container
+[38]:	#issues-writing-to-orcl-folder
+[39]:	http://joelkallman.blogspot.ca/2017/05/apex-and-ords-up-and-running-in2-steps.html
+[40]:	https://twitter.com/joelkallman
+[41]:	http://roelhartman.blogspot.ca/2017/10/dockerize-your-apex-development.html
+[42]:	https://twitter.com/RoelH
+[43]:	https://sqlmaria.com/2017/04/27/oracle-database-12c-now-available-on-docker/
+[44]:	https://twitter.com/sqlmaria
+[45]:	http://www.oracle.com/technetwork/developer-tools/sqlcl/overview/index.html
+[46]:	http://www.talkapex.com/2015/04/installing-sqlcl/
+[47]:	http://www.oracle.com/technetwork/developer-tools/apex/downloads/index.html
+[48]:	http://www.oracle.com/technetwork/developer-tools/apex/downloads/apex-51-archive-3661848.html
+[49]:	http://www.oracle.com/technetwork/developer-tools/apex/downloads/apex-5-archive-2606313.html
+[50]:	http://www.oracle.com/technetwork/developer-tools/rest-data-services/downloads
+[51]:	https://container-registry.oracle.com
+[52]:	https://github.com/oracle/docker-images/issues/646
+[53]:	https://github.com/martindsouza/docker-ords
+[54]:	https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+[55]:	https://twitter.com/joelkallman
+[56]:	http://joelkallman.blogspot.ca/2016/03/an-important-change-coming-for-oracle.html
+[57]:	https://github.com/martindsouza/docker-ords
+[58]:	http://localhost:32181/ords
+[59]:	https://docs.docker.com/engine/reference/run/#detached--d
+[60]:	https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/security-enhanced_linux/sect-security-enhanced_linux-enabling_and_disabling_selinux-disabling_selinux

--- a/README.md
+++ b/README.md
@@ -27,22 +27,24 @@ This is achieved using Oracle 12c containers (not to be confused with Docker con
 	- [CDB Setup][20]
 	- [PDB Setup][21]
 	  - [Create PDBs][22]
-	  - [APEX 5.0.4 Install][23]
+	  - [APEX 18.1 Install][23]
 	  - [APEX 5.1.3 Install][24]
-  - [ORDS Containers][25]
-	- [ORDS 5.0.4][26]
-	- [ORDS 5.1.3][27]
-	- [ORDS Container Wrappup][28]
-- [Useful Commands][29]
-  - [Quick Start][30]
-  - [Docker][31]
-  - [Oracle][32]
-	- [Connection Strings][33]
-	- [DBA][34]
-	- [Sample Data][35]
-- [Common Problems][36]
-  - [Oracle Docker Container][37]
-	- [Issues writing to `/ORCL` folder][38]
+	  - [APEX 5.0.4 Install][25]
+  - [ORDS Containers][26]
+	- [ORDS 18.1.0][27]
+	- [ORDS 5.1.3][28]
+	- [ORDS 5.0.4][29]
+	- [ORDS Container Wrappup][30]
+- [Useful Commands][31]
+  - [Quick Start][32]
+  - [Docker][33]
+  - [Oracle][34]
+	- [Connection Strings][35]
+	- [DBA][36]
+	- [Sample Data][37]
+- [Common Problems][38]
+  - [Oracle Docker Container][39]
+	- [Issues writing to `/ORCL` folder][40]
 
 <!-- /TOC -->
 
@@ -56,15 +58,15 @@ This is achieved using Oracle 12c containers (not to be confused with Docker con
 
  The following articles and all my scripts are a result of a combination of the code found in the links.
  
-- [APEX and ORDS up and running in....2 steps!][39] by [Joel Kallman][40]
-- [Dockerize your APEX development environment][41] by [Roel Hartman][42]
-- [Oracle Database 12c now available on Docker][43] by [Maria Colgan][44]
+- [APEX and ORDS up and running in....2 steps!][41] by [Joel Kallman][42]
+- [Dockerize your APEX development environment][43] by [Roel Hartman][44]
+- [Oracle Database 12c now available on Docker][45] by [Maria Colgan][46]
 
 ## Background
 
 - All my scripts are Linux / MacOS focused. If you use a Windows machine you'll need to translate
 - I specifically made reference to "your laptop" to emphasize what was run "on your machine" vs "in a docker container"
-- I use [SQLcl][45] instead of SQLplus on my laptop. I've also renamed the default command `sql` to `sqlcl`. You can use `sqlplus` or follow my [sqlcl install instructions][46].
+- I use [SQLcl][47] instead of SQLplus on my laptop. I've also renamed the default command `sql` to `sqlcl`. You can use `sqlplus` or follow my [sqlcl install instructions][48].
 
 ### Port Mapping
 
@@ -92,10 +94,10 @@ Due to licensing restrictions I can't host/provide these files in Github or else
 
 Application | Description
 --- | ---
-[APEX 18.1][47] | At the time of writing, 18.1 is the most recent version.
-[APEX 5.1.3][48] | Find it in the APEX archive page.
-[APEX 5.0.4][49] | Find it in the APEX archive page.
-[ORDS 17.4.1][50] | At the time of writing ORDS 17.4.1 was the most recent version.
+[APEX 18.1][49] | At the time of writing, 18.1 is the most recent version.
+[APEX 5.1.3][50] | Find it in the APEX archive page.
+[APEX 5.0.4][51] | Find it in the APEX archive page.
+[ORDS 18.1.1][52] | At the time of writing ORDS 18.1.1 was the most recent version.
 
 
 ### Laptop Folder Structure
@@ -115,7 +117,7 @@ Path | Description
 
 ### Oracle Container Registry Setup
 
-To work with Oracle's licensing for docker (and to avoid manually building images yourself) you'll need to login to the [container-registry.oracle.com][51] and use your Oracle Technology Network (OTN) login and register.
+To work with Oracle's licensing for docker (and to avoid manually building images yourself) you'll need to login to the [container-registry.oracle.com][53] and use your Oracle Technology Network (OTN) login and register.
 
 One logged in go to `Database > Enterprise` and read the license agreement. If you agree to the Terms and Conditions click the Accept button.
 
@@ -195,9 +197,9 @@ docker pull container-registry.oracle.com/database/enterprise:12.2.0.1
 
 #### ORDS
 
-*Oracle has scripts available to build an ORDS image. At the time of writing (11-Nov-2017) there's an issue with the script ([Issue #646][52]) that prevents me from using it. I suspect that Oracle will include a pre-built image on their container registry in the future so I'll update the section with their image when/if it becomes available. In the mean time the image will be built using another script.*
+*Oracle has scripts available to build an ORDS image. At the time of writing (11-Nov-2017) there's an issue with the script ([Issue #646][54]) that prevents me from using it. I suspect that Oracle will include a pre-built image on their container registry in the future so I'll update the section with their image when/if it becomes available. In the mean time the image will be built using another script.*
 
-**Important:** I've created a separate [ORDS Docker Image][53] repo. Since it's being actively updated and to avoid duplication of documentation please refer to the repo to build your ORDS Docker image. **Go through it now to create your ORDS Docker image**.
+**Important:** I've created a separate [ORDS Docker Image][55] repo. Since it's being actively updated and to avoid duplication of documentation please refer to the repo to build your ORDS Docker image. **Go through it now to create your ORDS Docker image**.
 
 #### Docker Image Confirmation
 
@@ -207,7 +209,7 @@ At this point you should see the following (or similar) output when running `doc
 docker images
 
 REPOSITORY                                          TAG                 IMAGE ID            CREATED             SIZE
-ords                                                17.4.1              a735271f7bf5        17 seconds ago      537MB
+ords                                                18.1.1              a735271f7bf5        17 seconds ago      537MB
 tomcat                                              8.0                 643bbbde6032        7 days ago          456MB
 container-registry.oracle.com/database/enterprise   12.2.0.1            12a359cd0528        2 months ago        3.44GB
 ```
@@ -219,7 +221,7 @@ Now that the setup is complete we can create all the Docker containers
 
 ### Oracle Container
 
-Adding the `-e TZ` option will set the appropriate timezone for the OS and the database. A full list of timezones can be found [here][54]. If excluded it will default to UTC.
+Adding the `-e TZ` option will set the appropriate timezone for the OS and the database. A full list of timezones can be found [here][56]. If excluded it will default to UTC.
 
 ```bash
 docker run -d -it \
@@ -250,7 +252,7 @@ You can follow the install by running `docker logs oracle`
 
 #### CDB Setup
 
-Starting in Oracle 12.2 the database should not come pre-installed with APEX. [Joel Kallman][55] wrote an [article][56] about why this. For some reason the container from Oracle comes with APEX 5.1.3 installed in the CDB. It must first be removed.
+Starting in Oracle 12.2 the database should not come pre-installed with APEX. [Joel Kallman][57] wrote an [article][58] about why this. For some reason the container from Oracle comes with APEX 5.1.3 installed in the CDB. It must first be removed.
 
 ```bash
 # On your laptop:
@@ -511,7 +513,7 @@ exit
 Each APEX PDB should have an associated ORDS container. A few notes about each ORDS container:
 
 - Instead of naming the ORDS containers with their version number, they'll be named to reference the corresponding APEX version. You may want to alter your naming scheme if you plan to test with multiple versions of ORDS.
-- **Important:** Refer to [Docker ORDS][57] documentation on how to run each ORDS setup. Only modifications will be mentioned in each section below.
+- **Important:** Refer to [Docker ORDS][59] documentation on how to run each ORDS setup. Only modifications will be mentioned in each section below.
 
 #### ORDS 18.1.0
 
@@ -531,7 +533,7 @@ docker run ...
   ...
 ```
 
-You should now be able to go to APEX via [http://localhost:31810/ords][58]
+You should now be able to go to APEX via [http://localhost:31810/ords][60]
 
 #### ORDS 5.1.3
 
@@ -577,7 +579,7 @@ You should now be able to go to APEX via http://localhost:32504/ords
 
 #### ORDS Container Wrappup
 
-When running ORDS containers for the first time they'll run in the foreground as the `-d` (`detached`) option was not provided (see [Docker documentation][59] for more info on this option). It's good to have it run in the foreground as it's easy to spot any issues with ORDS connecting to the database.
+When running ORDS containers for the first time they'll run in the foreground as the `-d` (`detached`) option was not provided (see [Docker documentation][61] for more info on this option). It's good to have it run in the foreground as it's easy to spot any issues with ORDS connecting to the database.
 
 To stop stop the container hit `ctrl+c`. To restart the ORDS container run `docker start ords-1810`.
 
@@ -695,7 +697,7 @@ mkdir: cannot create directory '/ORCL/u01': Permission denied
 
 It could be due to SE Linux. The following worked for me to get around this:
 
-- [Disable SE Linux][60]
+- [Disable SE Linux][62]
   - Set `SELINUX=disabled` in `/etc/selinux/config`
   - Reboot host OS (i.e. laptop)
   - Running `getenforce` should return `Disabled` or `Permissive`
@@ -732,41 +734,43 @@ chcon -Rt svirt_sandbox_file_t ~/docker/apex
 [20]:	#cdb-setup
 [21]:	#pdb-setup
 [22]:	#create-pdbs
-[23]:	#apex-504-install
+[23]:	#apex-181-install
 [24]:	#apex-513-install
-[25]:	#ords-containers
-[26]:	#ords-504
-[27]:	#ords-513
-[28]:	#ords-container-wrappup
-[29]:	#useful-commands
-[30]:	#quick-start
-[31]:	#docker
-[32]:	#oracle
-[33]:	#connection-strings
-[34]:	#dba
-[35]:	#sample-data
-[36]:	#common-problems
-[37]:	#oracle-docker-container
-[38]:	#issues-writing-to-orcl-folder
-[39]:	http://joelkallman.blogspot.ca/2017/05/apex-and-ords-up-and-running-in2-steps.html
-[40]:	https://twitter.com/joelkallman
-[41]:	http://roelhartman.blogspot.ca/2017/10/dockerize-your-apex-development.html
-[42]:	https://twitter.com/RoelH
-[43]:	https://sqlmaria.com/2017/04/27/oracle-database-12c-now-available-on-docker/
-[44]:	https://twitter.com/sqlmaria
-[45]:	http://www.oracle.com/technetwork/developer-tools/sqlcl/overview/index.html
-[46]:	http://www.talkapex.com/2015/04/installing-sqlcl/
-[47]:	http://www.oracle.com/technetwork/developer-tools/apex/downloads/index.html
-[48]:	http://www.oracle.com/technetwork/developer-tools/apex/downloads/apex-51-archive-3661848.html
-[49]:	http://www.oracle.com/technetwork/developer-tools/apex/downloads/apex-5-archive-2606313.html
-[50]:	http://www.oracle.com/technetwork/developer-tools/rest-data-services/downloads
-[51]:	https://container-registry.oracle.com
-[52]:	https://github.com/oracle/docker-images/issues/646
-[53]:	https://github.com/martindsouza/docker-ords
-[54]:	https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-[55]:	https://twitter.com/joelkallman
-[56]:	http://joelkallman.blogspot.ca/2016/03/an-important-change-coming-for-oracle.html
-[57]:	https://github.com/martindsouza/docker-ords
-[58]:	http://localhost:32181/ords
-[59]:	https://docs.docker.com/engine/reference/run/#detached--d
-[60]:	https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/security-enhanced_linux/sect-security-enhanced_linux-enabling_and_disabling_selinux-disabling_selinux
+[25]:	#apex-504-install
+[26]:	#ords-containers
+[27]:	#ords-1810
+[28]:	#ords-513
+[29]:	#ords-504
+[30]:	#ords-container-wrappup
+[31]:	#useful-commands
+[32]:	#quick-start
+[33]:	#docker
+[34]:	#oracle
+[35]:	#connection-strings
+[36]:	#dba
+[37]:	#sample-data
+[38]:	#common-problems
+[39]:	#oracle-docker-container
+[40]:	#issues-writing-to-orcl-folder
+[41]:	http://joelkallman.blogspot.ca/2017/05/apex-and-ords-up-and-running-in2-steps.html
+[42]:	https://twitter.com/joelkallman
+[43]:	http://roelhartman.blogspot.ca/2017/10/dockerize-your-apex-development.html
+[44]:	https://twitter.com/RoelH
+[45]:	https://sqlmaria.com/2017/04/27/oracle-database-12c-now-available-on-docker/
+[46]:	https://twitter.com/sqlmaria
+[47]:	http://www.oracle.com/technetwork/developer-tools/sqlcl/overview/index.html
+[48]:	http://www.talkapex.com/2015/04/installing-sqlcl/
+[49]:	http://www.oracle.com/technetwork/developer-tools/apex/downloads/index.html
+[50]:	http://www.oracle.com/technetwork/developer-tools/apex/downloads/apex-51-archive-3661848.html
+[51]:	http://www.oracle.com/technetwork/developer-tools/apex/downloads/apex-5-archive-2606313.html
+[52]:	http://www.oracle.com/technetwork/developer-tools/rest-data-services/downloads
+[53]:	https://container-registry.oracle.com
+[54]:	https://github.com/oracle/docker-images/issues/646
+[55]:	https://github.com/martindsouza/docker-ords
+[56]:	https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+[57]:	https://twitter.com/joelkallman
+[58]:	http://joelkallman.blogspot.ca/2016/03/an-important-change-coming-for-oracle.html
+[59]:	https://github.com/martindsouza/docker-ords
+[60]:	http://localhost:32181/ords
+[61]:	https://docs.docker.com/engine/reference/run/#detached--d
+[62]:	https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/security-enhanced_linux/sect-security-enhanced_linux-enabling_and_disabling_selinux-disabling_selinux

--- a/README.md
+++ b/README.md
@@ -2,49 +2,49 @@
 
 This document will keep an up to date version of my personal Oracle dockerized development environment. The main goal is to have one Oracle database with multiple versions of APEX installed. 
 
-This is achieved using Oracle 12c containers (not to be confused with Docker containers). If you're not too familiar with Oracle 12c containers I highly recommend reading [this][1] article which covers Container Databases (CDB) and Pluggable Databases (PDB).
+This is achieved using Oracle 12c containers (not to be confused with Docker containers). If you're not too familiar with Oracle 12c containers I highly recommend reading [this](http://www.oracle.com/technetwork/articles/database/multitenant-part1-pdbs-2193987.html) article which covers Container Databases (CDB) and Pluggable Databases (PDB).
 
 <!-- TOC depthFrom:2 -->
 
-- [Known Issues and Future Improvements][2]
-- [References][3]
-- [Background][4]
-  - [Port Mapping][5]
-  - [Passwords][6]
-  - [Download Files][7]
-  - [Laptop Folder Structure][8]
-  - [Oracle Container Registry Setup][9]
-- [Setup][10]
-  - [Directory structure][11]
-  - [Docker Network][12]
-  - [Docker Images][13]
-	- [Get Oracle Image][14]
-	- [ORDS][15]
-	- [Docker Image Confirmation][16]
-- [Docker Containers][17]
-  - [Oracle Container][18]
-  - [Oracle CDB and PDB Setup][19]
-	- [CDB Setup][20]
-	- [PDB Setup][21]
-	  - [Create PDBs][22]
-	  - [APEX 18.1 Install][23]
-	  - [APEX 5.1.3 Install][24]
-	  - [APEX 5.0.4 Install][25]
-  - [ORDS Containers][26]
-	- [ORDS 18.1.0][27]
-	- [ORDS 5.1.3][28]
-	- [ORDS 5.0.4][29]
-	- [ORDS Container Wrappup][30]
-- [Useful Commands][31]
-  - [Quick Start][32]
-  - [Docker][33]
-  - [Oracle][34]
-	- [Connection Strings][35]
-	- [DBA][36]
-	- [Sample Data][37]
-- [Common Problems][38]
-  - [Oracle Docker Container][39]
-	- [Issues writing to `/ORCL` folder][40]
+- [Known Issues and Future Improvements](#known-issues-and-future-improvements)
+- [References](#references)
+- [Background](#background)
+  - [Port Mapping](#port-mapping)
+  - [Passwords](#passwords)
+  - [Download Files](#download-files)
+  - [Laptop Folder Structure](#laptop-folder-structure)
+  - [Oracle Container Registry Setup](#oracle-container-registry-setup)
+- [Setup](#setup)
+  - [Directory structure](#directory-structure)
+  - [Docker Network](#docker-network)
+  - [Docker Images](#docker-images)
+  - [Get Oracle Image](#get-oracle-image)
+  - [ORDS](#ords)
+  - [Docker Image Confirmation](#docker-image-confirmation)
+- [Docker Containers](#docker-containers)
+  - [Oracle Container](#oracle-container)
+  - [Oracle CDB and PDB Setup](#oracle-cdb-and-pdb-setup)
+  - [CDB Setup](#cdb-setup)
+  - [PDB Setup](#pdb-setup)
+    - [Create PDBs](#create-pdbs)
+    - [APEX 18.1 Install](#apex-181-install)
+    - [APEX 5.1.3 Install](#apex-513-install)
+    - [APEX 5.0.4 Install](#apex-504-install)
+  - [ORDS Containers](#ords-containers)
+  - [ORDS 18.1.0](#ords-1810)
+  - [ORDS 5.1.3](#ords-513)
+  - [ORDS 5.0.4](#ords-504)
+  - [ORDS Container Wrappup](#ords-container-wrappup)
+- [Useful Commands](#useful-commands)
+  - [Quick Start](#quick-start)
+  - [Docker](#docker)
+  - [Oracle](#oracle)
+  - [Connection Strings](#connection-strings)
+  - [DBA](#dba)
+  - [Sample Data](#sample-data)
+- [Common Problems](#common-problems)
+  - [Oracle Docker Container](#oracle-docker-container)
+  - [Issues writing to `/ORCL` folder](#issues-writing-to-orcl-folder)
 
 <!-- /TOC -->
 
@@ -58,15 +58,15 @@ This is achieved using Oracle 12c containers (not to be confused with Docker con
 
  The following articles and all my scripts are a result of a combination of the code found in the links.
  
-- [APEX and ORDS up and running in....2 steps!][41] by [Joel Kallman][42]
-- [Dockerize your APEX development environment][43] by [Roel Hartman][44]
-- [Oracle Database 12c now available on Docker][45] by [Maria Colgan][46]
+- [APEX and ORDS up and running in....2 steps!](http://joelkallman.blogspot.ca/2017/05/apex-and-ords-up-and-running-in2-steps.html) by [Joel Kallman](https://twitter.com/joelkallman)
+- [Dockerize your APEX development environment](http://roelhartman.blogspot.ca/2017/10/dockerize-your-apex-development.html) by [Roel Hartman](https://twitter.com/RoelH)
+- [Oracle Database 12c now available on Docker](https://sqlmaria.com/2017/04/27/oracle-database-12c-now-available-on-docker/) by [Maria Colgan](https://twitter.com/sqlmaria)
 
 ## Background
 
 - All my scripts are Linux / MacOS focused. If you use a Windows machine you'll need to translate
 - I specifically made reference to "your laptop" to emphasize what was run "on your machine" vs "in a docker container"
-- I use [SQLcl][47] instead of SQLplus on my laptop. I've also renamed the default command `sql` to `sqlcl`. You can use `sqlplus` or follow my [sqlcl install instructions][48].
+- I use [SQLcl](http://www.oracle.com/technetwork/developer-tools/sqlcl/overview/index.html) instead of SQLplus on my laptop. I've also renamed the default command `sql` to `sqlcl`. You can use `sqlplus` or follow my [sqlcl install instructions](http://www.talkapex.com/2015/04/installing-sqlcl/).
 
 ### Port Mapping
 
@@ -94,10 +94,10 @@ Due to licensing restrictions I can't host/provide these files in Github or else
 
 Application | Description
 --- | ---
-[APEX 18.1][49] | At the time of writing, 18.1 is the most recent version.
-[APEX 5.1.3][50] | Find it in the APEX archive page.
-[APEX 5.0.4][51] | Find it in the APEX archive page.
-[ORDS 18.1.1][52] | At the time of writing ORDS 18.1.1 was the most recent version.
+[APEX 18.1](http://www.oracle.com/technetwork/developer-tools/apex/downloads/index.html) | At the time of writing, 18.1 is the most recent version.
+[APEX 5.1.3](http://www.oracle.com/technetwork/developer-tools/apex/downloads/apex-51-archive-3661848.html) | Find it in the APEX archive page.
+[APEX 5.0.4](http://www.oracle.com/technetwork/developer-tools/apex/downloads/apex-5-archive-2606313.html) | Find it in the APEX archive page.
+[ORDS 18.1.1](http://www.oracle.com/technetwork/developer-tools/rest-data-services/downloads) | At the time of writing ORDS 18.1.1 was the most recent version.
 
 
 ### Laptop Folder Structure
@@ -117,7 +117,7 @@ Path | Description
 
 ### Oracle Container Registry Setup
 
-To work with Oracle's licensing for docker (and to avoid manually building images yourself) you'll need to login to the [container-registry.oracle.com][53] and use your Oracle Technology Network (OTN) login and register.
+To work with Oracle's licensing for docker (and to avoid manually building images yourself) you'll need to login to the [container-registry.oracle.com](https://container-registry.oracle.com) and use your Oracle Technology Network (OTN) login and register.
 
 One logged in go to `Database > Enterprise` and read the license agreement. If you agree to the Terms and Conditions click the Accept button.
 
@@ -197,9 +197,9 @@ docker pull container-registry.oracle.com/database/enterprise:12.2.0.1
 
 #### ORDS
 
-*Oracle has scripts available to build an ORDS image. At the time of writing (11-Nov-2017) there's an issue with the script ([Issue #646][54]) that prevents me from using it. I suspect that Oracle will include a pre-built image on their container registry in the future so I'll update the section with their image when/if it becomes available. In the mean time the image will be built using another script.*
+*Oracle has scripts available to build an ORDS image. At the time of writing (11-Nov-2017) there's an issue with the script ([Issue #646](https://github.com/oracle/docker-images/issues/646)) that prevents me from using it. I suspect that Oracle will include a pre-built image on their container registry in the future so I'll update the section with their image when/if it becomes available. In the mean time the image will be built using another script.*
 
-**Important:** I've created a separate [ORDS Docker Image][55] repo. Since it's being actively updated and to avoid duplication of documentation please refer to the repo to build your ORDS Docker image. **Go through it now to create your ORDS Docker image**.
+**Important:** I've created a separate [ORDS Docker Image](https://github.com/martindsouza/docker-ords) repo. Since it's being actively updated and to avoid duplication of documentation please refer to the repo to build your ORDS Docker image. **Go through it now to create your ORDS Docker image**.
 
 #### Docker Image Confirmation
 
@@ -221,7 +221,7 @@ Now that the setup is complete we can create all the Docker containers
 
 ### Oracle Container
 
-Adding the `-e TZ` option will set the appropriate timezone for the OS and the database. A full list of timezones can be found [here][56]. If excluded it will default to UTC.
+Adding the `-e TZ` option will set the appropriate timezone for the OS and the database. A full list of timezones can be found [here](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). If excluded it will default to UTC.
 
 ```bash
 docker run -d -it \
@@ -252,7 +252,7 @@ You can follow the install by running `docker logs oracle`
 
 #### CDB Setup
 
-Starting in Oracle 12.2 the database should not come pre-installed with APEX. [Joel Kallman][57] wrote an [article][58] about why this. For some reason the container from Oracle comes with APEX 5.1.3 installed in the CDB. It must first be removed.
+Starting in Oracle 12.2 the database should not come pre-installed with APEX. [Joel Kallman](https://twitter.com/joelkallman) wrote an [article](http://joelkallman.blogspot.ca/2016/03/an-important-change-coming-for-oracle.html) about why this. For some reason the container from Oracle comes with APEX 5.1.3 installed in the CDB. It must first be removed.
 
 ```bash
 # On your laptop:
@@ -513,7 +513,7 @@ exit
 Each APEX PDB should have an associated ORDS container. A few notes about each ORDS container:
 
 - Instead of naming the ORDS containers with their version number, they'll be named to reference the corresponding APEX version. You may want to alter your naming scheme if you plan to test with multiple versions of ORDS.
-- **Important:** Refer to [Docker ORDS][59] documentation on how to run each ORDS setup. Only modifications will be mentioned in each section below.
+- **Important:** Refer to [Docker ORDS](https://github.com/martindsouza/docker-ords) documentation on how to run each ORDS setup. Only modifications will be mentioned in each section below.
 
 #### ORDS 18.1.0
 
@@ -533,7 +533,7 @@ docker run ...
   ...
 ```
 
-You should now be able to go to APEX via [http://localhost:31810/ords][60]
+You should now be able to go to APEX via [http://localhost:31810/ords](http://localhost:32181/ords)
 
 #### ORDS 5.1.3
 
@@ -579,7 +579,7 @@ You should now be able to go to APEX via http://localhost:32504/ords
 
 #### ORDS Container Wrappup
 
-When running ORDS containers for the first time they'll run in the foreground as the `-d` (`detached`) option was not provided (see [Docker documentation][61] for more info on this option). It's good to have it run in the foreground as it's easy to spot any issues with ORDS connecting to the database.
+When running ORDS containers for the first time they'll run in the foreground as the `-d` (`detached`) option was not provided (see [Docker documentation](https://docs.docker.com/engine/reference/run/#detached--d) for more info on this option). It's good to have it run in the foreground as it's easy to spot any issues with ORDS connecting to the database.
 
 To stop stop the container hit `ctrl+c`. To restart the ORDS container run `docker start ords-1810`.
 
@@ -697,7 +697,7 @@ mkdir: cannot create directory '/ORCL/u01': Permission denied
 
 It could be due to SE Linux. The following worked for me to get around this:
 
-- [Disable SE Linux][62]
+- [Disable SE Linux](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/security-enhanced_linux/sect-security-enhanced_linux-enabling_and_disabling_selinux-disabling_selinux)
   - Set `SELINUX=disabled` in `/etc/selinux/config`
   - Reboot host OS (i.e. laptop)
   - Running `getenforce` should return `Disabled` or `Permissive`
@@ -711,66 +711,3 @@ chmod 777 ~/docker/apex
 chcon -Rt svirt_sandbox_file_t ~/docker/oracle
 chcon -Rt svirt_sandbox_file_t ~/docker/apex
 ```
-
-[1]:	http://www.oracle.com/technetwork/articles/database/multitenant-part1-pdbs-2193987.html
-[2]:	#known-issues-and-future-improvements
-[3]:	#references
-[4]:	#background
-[5]:	#port-mapping
-[6]:	#passwords
-[7]:	#download-files
-[8]:	#laptop-folder-structure
-[9]:	#oracle-container-registry-setup
-[10]:	#setup
-[11]:	#directory-structure
-[12]:	#docker-network
-[13]:	#docker-images
-[14]:	#get-oracle-image
-[15]:	#ords
-[16]:	#docker-image-confirmation
-[17]:	#docker-containers
-[18]:	#oracle-container
-[19]:	#oracle-cdb-and-pdb-setup
-[20]:	#cdb-setup
-[21]:	#pdb-setup
-[22]:	#create-pdbs
-[23]:	#apex-181-install
-[24]:	#apex-513-install
-[25]:	#apex-504-install
-[26]:	#ords-containers
-[27]:	#ords-1810
-[28]:	#ords-513
-[29]:	#ords-504
-[30]:	#ords-container-wrappup
-[31]:	#useful-commands
-[32]:	#quick-start
-[33]:	#docker
-[34]:	#oracle
-[35]:	#connection-strings
-[36]:	#dba
-[37]:	#sample-data
-[38]:	#common-problems
-[39]:	#oracle-docker-container
-[40]:	#issues-writing-to-orcl-folder
-[41]:	http://joelkallman.blogspot.ca/2017/05/apex-and-ords-up-and-running-in2-steps.html
-[42]:	https://twitter.com/joelkallman
-[43]:	http://roelhartman.blogspot.ca/2017/10/dockerize-your-apex-development.html
-[44]:	https://twitter.com/RoelH
-[45]:	https://sqlmaria.com/2017/04/27/oracle-database-12c-now-available-on-docker/
-[46]:	https://twitter.com/sqlmaria
-[47]:	http://www.oracle.com/technetwork/developer-tools/sqlcl/overview/index.html
-[48]:	http://www.talkapex.com/2015/04/installing-sqlcl/
-[49]:	http://www.oracle.com/technetwork/developer-tools/apex/downloads/index.html
-[50]:	http://www.oracle.com/technetwork/developer-tools/apex/downloads/apex-51-archive-3661848.html
-[51]:	http://www.oracle.com/technetwork/developer-tools/apex/downloads/apex-5-archive-2606313.html
-[52]:	http://www.oracle.com/technetwork/developer-tools/rest-data-services/downloads
-[53]:	https://container-registry.oracle.com
-[54]:	https://github.com/oracle/docker-images/issues/646
-[55]:	https://github.com/martindsouza/docker-ords
-[56]:	https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-[57]:	https://twitter.com/joelkallman
-[58]:	http://joelkallman.blogspot.ca/2016/03/an-important-change-coming-for-oracle.html
-[59]:	https://github.com/martindsouza/docker-ords
-[60]:	http://localhost:32181/ords
-[61]:	https://docs.docker.com/engine/reference/run/#detached--d
-[62]:	https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/security-enhanced_linux/sect-security-enhanced_linux-enabling_and_disabling_selinux-disabling_selinux


### PR DESCRIPTION
Enhancement #6 

I switch the order in some steps and had 18.1.0 first and 5.1.3 second.
I think this will allow those that only want 18.1 to do the first step and then stop. Or two versions, do the first two.